### PR TITLE
add new display field to indicate optional client display of identifiers

### DIFF
--- a/app/models/fields/field.rb
+++ b/app/models/fields/field.rb
@@ -27,7 +27,7 @@ class Field
 
   def id
     value = "#{record.dig(:Header, :DbId)}_#{record.dig(:Header, :An)}"
-    { name: 'id', label: 'Identifier', value: value }.merge(detailed_text)
+    { name: 'id', label: 'Identifier', value: value, display: 'optional' }.merge(detailed_text)
   end
 
   def doi


### PR DESCRIPTION
The client will display "optional" fields according to user preference (right now they are simply hidden).  A full controlled vocabulary for the "display" field is TBD.